### PR TITLE
fix(CI): GitHub deprecated v1 use docker compose instead of docker-compose

### DIFF
--- a/.github/workflows/deploy-image.yaml
+++ b/.github/workflows/deploy-image.yaml
@@ -34,8 +34,9 @@ jobs:
           IMAGE_TAG: prod-${{ github.sha }}
         run: |
           echo "image_tag=$IMAGE_TAG" >> $GITHUB_OUTPUT
-          CURRENT_UID=$(id -u):$(id -g) docker-compose --project-name "common-voice" -f "docker-compose.yaml" build web
-          docker tag common-voice_web:latest $REGISTRY/$REPOSITORY:$IMAGE_TAG
+          CURRENT_UID=$(id -u):$(id -g) docker compose --project-name "common-voice" -f "docker-compose.yaml" build web
+          docker image ls
+          docker tag common-voice-web:latest $REGISTRY/$REPOSITORY:$IMAGE_TAG
           docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
 
       - name: Repository dispatch to trigger deployment

--- a/.github/workflows/stage-deploy-image.yaml
+++ b/.github/workflows/stage-deploy-image.yaml
@@ -37,8 +37,9 @@ jobs:
           IMAGE_TAG: stage-${{ github.sha }}
         run: |
           echo "image_tag=$IMAGE_TAG" >> $GITHUB_OUTPUT
-          CURRENT_UID=$(id -u):$(id -g) docker-compose --project-name "common-voice" -f "docker-compose.yaml" build web
-          docker tag common-voice_web:latest $REGISTRY/$REPOSITORY:$IMAGE_TAG
+          CURRENT_UID=$(id -u):$(id -g) docker compose --project-name "common-voice" -f "docker-compose.yaml" build web
+          docker image ls
+          docker tag common-voice-web:latest $REGISTRY/$REPOSITORY:$IMAGE_TAG
           docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
 
       - name: Repository dispatch to trigger deployment

--- a/docker-compose.override.yaml
+++ b/docker-compose.override.yaml
@@ -2,8 +2,6 @@
 # wget 'https://github.com/docker/compose-cli/releases/download/v1.0.29/docker-linux-amd64'
 # CURRENT_UID=$(id -u):$(id -g) ./docker-linux-amd64 --context ecs.common-voice compose --project-name common-voice up
 
-version: '3'
-
 services:
   web:
     ports:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   db:
     image: mysql:5.7.28


### PR DESCRIPTION
Our PAT had expired and after updating it, the workflow was failing on `docker-compose`.
`docker-compose` is deprecated since around 2024-04-01 in github workflows
`version` is obsolete and generated an unnecessary warning.
`docker compose` generates a slightly different image name.